### PR TITLE
Update backup function and remove outdated social media references

### DIFF
--- a/functions/embedify.ts
+++ b/functions/embedify.ts
@@ -33,7 +33,7 @@ export async function embedify(link: string) {
 
 export function backup(originalLink: string) {
   if (originalLink.includes("instagram.")) {
-    originalLink = originalLink.replace("instagram", "kkinstagram");
+    originalLink = originalLink.replace("instagram", "kkclip");
   } else if (originalLink.includes("tiktok.")) {
     originalLink = originalLink.replace("tiktok", "tnktok");
   }

--- a/functions/sendMeme.ts
+++ b/functions/sendMeme.ts
@@ -12,13 +12,6 @@ export async function sendMeme(
     return;
   }
 
-  if (link.includes("sora.chatgpt.com")) {
-    await channel.send(
-      `Whoops! ${user} tried to send AI slop! We don't support that here. Please reevaluate your life choices.`
-    );
-    throw new Error("Error processing link.");
-  }
-
   const info = await embedify(link);
 
   if (info === null) {


### PR DESCRIPTION
This pull request makes minor adjustments to the meme handling and backup link logic. The main changes are an update to the Instagram backup domain and the removal of a block that prevented sending certain AI-generated links.

- Backup link logic:
  * Changed the Instagram backup domain replacement from `kkinstagram` to `kkclip` in the `backup` function of `embedify.ts`.

- Meme sending restrictions:
  * Removed the check that blocked links containing `sora.chatgpt.com`, allowing these links to be processed and sent.